### PR TITLE
Fixed PermitJoin interval issue

### DIFF
--- a/lib/components/controller.js
+++ b/lib/components/controller.js
@@ -47,6 +47,7 @@ function Controller(shepherd, cfg) {
     this._spinLock = false;
     this._joinQueue = [];
     this._permitJoinTime = 0;
+    this._permitJoinInterval;
 
     this._net = {
         state: null,
@@ -319,9 +320,10 @@ Controller.prototype.permitJoin = function (time, type, callback) {
         self.emit('permitJoining', self._permitJoinTime);
 
         if (time !== 0 && time !== 255) {
-            var timeDownCounter = setInterval(function () {
+            clearInterval(self._permitJoinInterval);
+            self._permitJoinInterval = setInterval(function () {
                 if (self.permitJoinCountdown() === 0)
-                    clearInterval(timeDownCounter);
+                    clearInterval(self._permitJoinInterval);
                 self.emit('permitJoining', self._permitJoinTime);
             }, 1000);
         }


### PR DESCRIPTION
Hello,

I ran into an issue where if you ran join, and then ran it again, there would be two intervals running.
This would cause the countdown to go twice as fast, and when it hit 0, only one would be cancelled making the interval run forever, emitting negative numbers

This fixes that issue

- Nick Remijn