### PR TITLE
Add retry on failed endpoint bind

### DIFF
--- a/lib/components/querie.js
+++ b/lib/components/querie.js
@@ -137,11 +137,15 @@ querie.setBindingEntry = function (bindMode, srcEp, cId, dstEpOrGrpId, callback)
         req = function () { return controller.request('ZDO', 'unbindReq', bindParams); };
     }
 
-    req().then(function (rsp) {
-        deferred.resolve();
-    }).fail(function (err) {
-        deferred.reject(err);
-    }).done();
+	(function performReq(retryAttempts) {
+		if (typeof retryAttempts === 'undefined') retryAttempts = 0;
+		req().then(function (rsp) {
+			deferred.resolve();
+		}).fail(function (err) {
+			if(retryAttempts >= 4) return deferred.reject(err);
+			else performReq(++retryAttempts);
+		}).done();
+	})();
 
     return deferred.promise.nodeify(callback);
 };


### PR DESCRIPTION
Failing bind seems to happen a lot, for unknown reasons. Adding the
retries filters out most of failures.

For this an arbitrary value of 4 was chosen.