### PR TITLE
Try/catch ep.report() input values

### DIFF
--- a/lib/shepherd.js
+++ b/lib/shepherd.js
@@ -151,7 +151,7 @@ ZShepherd.prototype.start = function (callback) {
     var self = this;
 
     return init.setupShepherd(this).then(function () {
-        self._enabled = true;   // shepherd is enabled 
+        self._enabled = true;   // shepherd is enabled
         self.emit('_ready');    // if all done, shepherd fires '_ready' event for inner use
     }).nodeify(callback);
 };
@@ -463,15 +463,16 @@ ZShepherd.prototype._attachZclMethods = function (ep) {
                     deferred.reject(new Error('request unsuccess: ' + rec.status));
             });
 
-            return deferred.promise.nodeify(callback);
-        };
-        ep.report = function (cId, attrId, minInt, maxInt, repChange, callback) {
-            var deferred = Q.defer(),
-                coord = self.controller.getCoord(),
-                dlgEp = coord.getDelegator(ep.getProfId()),
-                cfgRpt = true,
-                cfgRptRec,
-                attrIdVal;
+			return deferred.promise.nodeify(callback);
+		};
+		ep.report = function (cId, attrId, minInt, maxInt, repChange, callback) {
+			var deferred = Q.defer(),
+				coord = self.controller.getCoord(),
+				dlgEp = coord.getDelegator(ep.getProfId()),
+				cfgRpt = true,
+				cfgRptRec,
+				attrIdVal,
+				attrTypeVal;
 
              if (arguments.length === 1) {
                 cfgRpt = false;
@@ -482,17 +483,22 @@ ZShepherd.prototype._attachZclMethods = function (ep) {
                 callback = repChange;
             }
 
-            if (cfgRpt) {
-                attrIdVal = zclId.attr(cId, attrId);
-                cfgRptRec = {
-                    direction : 0,
-                    attrId: attrIdVal ? attrIdVal.value : attrId,
-                    dataType : zclId.attrType(cId, attrId).value,
-                    minRepIntval : minInt,
-                    maxRepIntval : maxInt,
-                    repChange: repChange
-                };
-            }
+			if (cfgRpt) {
+				try {
+					attrIdVal = zclId.attr(cId, attrId);
+					attrTypeVal = zclId.attrType(cId, attrId).value
+				} catch (err) {
+					return Q.reject(new Error('Invalid cluster or attr'));
+				}
+				cfgRptRec = {
+					direction : 0,
+					attrId: attrIdVal ? attrIdVal.value : attrId,
+					dataType : attrTypeVal,
+					minRepIntval : minInt,
+					maxRepIntval : maxInt,
+					repChange: repChange
+				};
+			}
 
             Q.fcall(function () {
                 if (dlgEp) {


### PR DESCRIPTION
This makes sure shepherd does not crash when `ep.report()` is called with invalid cluster/attr values.