### PR TITLE
Expose database methods

### DIFF
--- a/lib/shepherd.js
+++ b/lib/shepherd.js
@@ -157,8 +157,10 @@ ZShepherd.prototype.start = function (callback) {
 };
 
 ZShepherd.prototype.validateDatabase = function(path) {
+	if(typeof path !== 'string') return Promise.reject(new Error('missing_db_path'));
+
 	var nedDB = new NedDB({
-		filename: path || this._dbPath,
+		filename: path,
 		autoload: false
 	});
 
@@ -171,10 +173,8 @@ ZShepherd.prototype.validateDatabase = function(path) {
 };
 
 ZShepherd.prototype.initDatabase = function() {
-	var self = this;
-
 	try {
-		this._devbox = new Objectbox(self._dbPath);
+		this._devbox = new Objectbox(this._dbPath);
 	} catch (err) {
 		console.error('database error, could not start object box')
 	}

--- a/lib/shepherd.js
+++ b/lib/shepherd.js
@@ -6,19 +6,19 @@ var fs = require('fs'),
     EventEmitter = require('events');
 
 var Q = require('q'),
-    _ = require('busyman'),
-    Zive = require('zive'),
-    zclId = require('zcl-id'),
-    proving = require('proving'),
-    Objectbox = require('objectbox'),
-    debug = { shepherd: require('debug')('zigbee-shepherd') };
+	_ = require('busyman'),
+	Zive = require('zive'),
+	NedDB = require('nedb'),
+	zclId = require('zcl-id'),
+	proving = require('proving'),
+	Objectbox = require('objectbox'),
+	debug = { shepherd: require('debug')('zigbee-shepherd') };
 
-var af = require('./components/af'),
-    init = require('./initializers/init_shepherd'),
-    zutils = require('./components/zutils'),
-    loader = require('./components/loader'),
-    Controller = require('./components/controller'),
-    eventHandlers = require('./components/event_handlers');
+var init = require('./initializers/init_shepherd'),
+	zutils = require('./components/zutils'),
+	loader = require('./components/loader'),
+	Controller = require('./components/controller'),
+	eventHandlers = require('./components/event_handlers');
 
 var Device = require('./model/device'),
     Coordinator = require('./model/coord'),
@@ -151,9 +151,33 @@ ZShepherd.prototype.start = function (callback) {
     var self = this;
 
     return init.setupShepherd(this).then(function () {
-        self._enabled = true;   // shepherd is enabled 
+        self._enabled = true;   // shepherd is enabled
         self.emit('_ready');    // if all done, shepherd fires '_ready' event for inner use
     }).nodeify(callback);
+};
+
+ZShepherd.prototype.validateDatabase = function(path) {
+	var nedDB = new NedDB({
+		filename: path || this._dbPath,
+		autoload: false
+	});
+
+	return new Promise(function(resolve, reject){
+		nedDB.loadDatabase(function(err) {
+			if(err) return reject(err);
+			return resolve();
+		})
+	})
+};
+
+ZShepherd.prototype.initDatabase = function() {
+	var self = this;
+
+	try {
+		this._devbox = new Objectbox(self._dbPath);
+	} catch (err) {
+		console.error('database error, could not start object box')
+	}
 };
 
 ZShepherd.prototype.stop = function (callback) {


### PR DESCRIPTION
NOTE: breaking, it requires `initDatabase()` to be called before it will be usable.

This was needed to validate the database (for corruptions) before completely starting zigbee-shepherd. I expect this is not desired for you to merge, but still I'd like to offer it. Maybe we can introduce a flag which will by default call `initDatabase()`.